### PR TITLE
 Allow users to set component name in remote state

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -2,7 +2,7 @@ module "account_map" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component   = "account-map"
+  component   = var.account_map_component_name
   tenant      = var.account_map_tenant != "" ? var.account_map_tenant : module.this.tenant
   stage       = var.root_account_stage
   environment = var.global_environment

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -4,6 +4,12 @@ variable "account_map_tenant" {
   description = "The tenant where the `account_map` component required by remote-state is deployed"
 }
 
+variable "account_map_component_name" {
+  type        = string
+  description = "The name of the account-map component"
+  default     = "account-map"
+}
+
 variable "admin_delegated" {
   type        = bool
   default     = false


### PR DESCRIPTION
Allow users to set component name in remote state.

* Defined the input variable `account_map_component_name`.
* Variable defaults to preserving the behavior of the current version.
* Remote state uses this variable to pull in the state of the component.
* This update allows the codebase to adopt more standardized structure and naming practices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The account-map component name is now configurable via a new input variable (default: "account-map"), allowing environment-specific naming without code changes.
  * Remote-state configuration now consumes this variable while preserving existing behavior by default for seamless upgrades.
  * No other parameters were changed; no downtime or plan changes expected unless you override the default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->