### PR TITLE
feat: expose finding_severity_labels to filter SNS notifications by severity

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -52,6 +52,7 @@ module "security_hub" {
 
 
   cloudwatch_event_rule_pattern_detail_type = var.cloudwatch_event_rule_pattern_detail_type
+  finding_severity_labels                   = var.finding_severity_labels
   create_sns_topic                          = local.create_sns_topic
   enable_default_standards                  = var.default_standards_enabled
   enabled_standards                         = var.enabled_standards

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -97,6 +97,13 @@ variable "finding_severity_labels" {
   For the list of valid severity labels, see:
   https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_Severity.html
   DOC
+
+  validation {
+    condition = alltrue([
+      for label in var.finding_severity_labels : contains(["INFORMATIONAL", "LOW", "MEDIUM", "HIGH", "CRITICAL"], label)
+    ])
+    error_message = "finding_severity_labels may only contain: INFORMATIONAL, LOW, MEDIUM, HIGH, CRITICAL."
+  }
 }
 
 variable "create_sns_topic" {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -85,6 +85,20 @@ variable "cloudwatch_event_rule_pattern_detail_type" {
   DOC
 }
 
+variable "finding_severity_labels" {
+  type        = list(string)
+  default     = []
+  description = <<-DOC
+  A list of finding severity labels used to filter which Security Hub findings are forwarded to notifications, e.g.
+  `["CRITICAL", "HIGH"]`. When empty (the default), findings of all severities matching
+  `cloudwatch_event_rule_pattern_detail_type` are forwarded, preserving prior behavior. Requires the underlying
+  `cloudposse/security-hub/aws` module `>= 0.13.0`.
+
+  For the list of valid severity labels, see:
+  https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_Severity.html
+  DOC
+}
+
 variable "create_sns_topic" {
   type        = bool
   default     = false


### PR DESCRIPTION
## what

- Add a `finding_severity_labels` input (`list(string)`, default `[]`) and pass it to the wrapped `cloudposse/security-hub/aws` module.

## why

- The module was bumped to `0.13.0` (#58), which added `finding_severity_labels` — but the component never surfaced it. So `create_sns_topic` callers could only forward **every** imported finding (`INFORMATIONAL`/`LOW` included) to SNS, which is unusable noise for email/paging subscribers.
- Empty default preserves current behavior (all severities); `["CRITICAL", "HIGH"]` forwards only those. Fully backward-compatible.

## test

- `terraform fmt` clean.
- Requires module `>= 0.13.0` (already pinned on `main` via #58).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional configuration setting to filter Security Hub findings by severity before they are sent to notifications.
  * Leaving the setting empty preserves the existing behavior across all severities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->